### PR TITLE
Fix: Potential bug if this and sheet are different

### DIFF
--- a/SpreadsheetManager.js
+++ b/SpreadsheetManager.js
@@ -28,8 +28,7 @@ class SpreadsheetManager{
     * @return array of data from sheet
   */
   getSheetValues(){
-    const { sheet } = this;
-    const values = sheet.getDataRange().getValues();
+    const values = this.sheet.getDataRange().getValues();
     return values;
   }
   /**


### PR DESCRIPTION
If this and sheet are not the same object (ie when there are several sheets in a workbook) then getSheetValues() had a potential bug. This is a pull request to fix the bug.